### PR TITLE
chore: use public ecr repository

### DIFF
--- a/.vtex/drone.yml
+++ b/.vtex/drone.yml
@@ -9,15 +9,15 @@ steps:
     - make test
 
   - name: publish-ecr
-    image: plugins/ecr
+    image: plugins/kaniko-ecr
     when:
       event: tag
     settings:
       repo: cleaner-controller
-      registry: 558830342743.dkr.ecr.us-east-1.amazonaws.com
+      registry: public.ecr.aws/f8y0w2c4
       region: us-east-1
       dockerfile: Dockerfile
-      create_repository: true
+      create_repository: false
       access_key:
         from_secret: 558830342743_AWS_ACCESS_KEY_ID
       secret_key:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= 558830342743.dkr.ecr.us-east-1.amazonaws.com/cleaner-controller:$(VERSION)
+IMG ?= public.ecr.aws/f8y0w2c4/cleaner-controller:$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 


### PR DESCRIPTION
Moves to public ECR repository and uses `kaniko-ecr` plugin instead of drone's own because it doesn't support it:
https://github.com/drone-plugins/drone-docker/pull/357 