### PR TITLE
[CLOUD-20] Add OpenSearch labels cleaner controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ HELMIFY ?= $(LOCALBIN)/helmify
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
+KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.3
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/config/manager/config.yaml
+++ b/config/manager/config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cleaner-controller-logs-config
+  namespace: system
 data:
   journey: '{{ .Values.opensearch.journey | default "not-configured" }}'
   search_index: '{{ .Values.opensearch.search_index | default "not-configured" }}'

--- a/config/manager/config.yaml
+++ b/config/manager/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cleaner-controller-logs-config
+data:
+  journey: '{{ .Values.opensearch.journey | default "not-configured" }}'
+  search_index: '{{ .Values.opensearch.search_index | default "not-configured" }}'

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
 - manager.yaml
 commonLabels:
-  journey: '{{ .Values.opensearch.journey | default "not-configured" }}}'
-  search_index: '{{ .Values.opensearch.search_index | default "not-configured" }}}'
+  journey: '{{ .Values.opensearch.journey | default "not-configured" }}'
+  search_index: '{{ .Values.opensearch.search_index | default "not-configured" }}'

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,31 @@
 resources:
 - manager.yaml
-commonLabels:
-  journey: '{{ .Values.opensearch.journey | default "not-configured" }}'
-  search_index: '{{ .Values.opensearch.search_index | default "not-configured" }}'
+- config.yaml
+
+replacements:
+- source:
+    fieldPath: data.journey
+    kind: ConfigMap
+    name: cleaner-controller-logs-config
+  targets:
+  - fieldPaths:
+    - spec.template.metadata.labels.journey
+    select:
+      kind: Deployment
+      name: controller-manager
+- source:
+    fieldPath: data.search_index
+    kind: ConfigMap
+    name: cleaner-controller-logs-config
+  targets:
+  - fieldPaths:
+    - spec.template.metadata.labels.search_index
+    select:
+      kind: Deployment
+      name: controller-manager
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: public.ecr.aws/f8y0w2c4/cleaner-controller
+  newTag: manager-local-v0.2.0-beta.3

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
 - manager.yaml
+commonLabels:
+  journey: '{{ .Values.opensearch.journey | default "not-configured" }}}'
+  search_index: '{{ .Values.opensearch.search_index | default "not-configured" }}}'

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,8 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        journey: "not-configured"
+        search_index: "not-configured"
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution. 


### PR DESCRIPTION
# Description
Within this PR, we're configuring the labels `journey` and `search_index`, so we can configure OpenSearch logs for the `controller-manager` deployment. 
One thing to notice here is that we're trying to add this label in a way that it's not mandatory for everyone deploying this chart, since Homebrew is not the only one to use it. 

# What was done
- [x] Add `journey` and `search_index` labels
- [x] Update `kustomize` version 